### PR TITLE
update build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0001-16920-Mark-vtkPainterCommunicator-as-not-wrappable.patch
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
Both PR #15 and #12 have increased build number from 0 to 1.

PR #15 should have increase build number from 1 to 2 instead.

I don't know how much it's a problem that PR #15 has wrong build number. Maybe binaries on anaconda.org will overwrite those from PR #12, and user having already installed binaries with build number 1 will not be able to update to the new binaries including PR #15 (as the build number is the same, the package will be considered up to date)?