### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0001-16920-Mark-vtkPainterCommunicator-as-not-wrappable.patch
 
 build:
-  number: 3
+  number: 4
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
@@ -34,7 +34,7 @@ requirements:
     # VTK Third Party dependencies
     - zlib 1.2.*
     - freetype 2.7.*
-    - hdf5 1.8.17|1.8.17.*  # [unix]
+    - hdf5 1.8.18|1.8.18.*  # [unix]
     - libxml2 2.9.*
     - libpng >=1.6.23,<1.7
     - jpeg 9*
@@ -47,7 +47,7 @@ requirements:
     # VTK Third Party dependencies
     - zlib 1.2.*
     - freetype 2.7.*
-    - hdf5 1.8.17|1.8.17.*  # [unix]
+    - hdf5 1.8.18|1.8.18.*  # [unix]
     - libxml2 2.9.*
     - libpng >=1.6.23,<1.7
     - jpeg 9*


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71