### PR TITLE
Drop vc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 2d5cdd048540144d821715c718932591418bb48f5b6bb19becdae62339efa75a
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,6 @@ source:
 
 build:
   number: 0
-  features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and py35]
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
As `python` is already a `build` and `run` dependency of `vtk`, the `vc` dependence is already correctly set through `python`. So there is no need to have `vtk` depend on `vc` as well. Hence we drop `vc` features and bump the build number.