### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+os: osx
+osx_image: xcode6.4
+
+env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "fhS9RaksW9C7p2Rw+f47sjuEV4IWQBG8C5YYCfxAIMTBEpdLcAeDYJshjchdn7qpQf8J3vOidWGnDJ5EetWvW9sHfcahL3KKLYEqTqKV066lHQkGl5TfT+ehYimrOKP0XhS2Y472FF3WuTARkZKSGFduKNfbgwLIus0udST4oHPlO/mdnvRO73W0GeU+QxH/y7RTWhjUIFI7e+9LWlv3B3pyaoiwyIr8IXrgPlv3szq8ip36knaLs9EG47+NgZn2mltXgIn0fOW/b4ljaispw7hSCGBvSEuitU23d0aTwI5rFRDdIpWG7hkStLrBZTBZEH76Z7ZlLoza1TYElaZJO4tJVhpKQ5kF8ECXSr6usi3p4i3nmOTOr31uXiZKfpptiYGXKg4Ckc60QKyl8FXlVoCCWMn20KsNepwDhavf+nptqf7tpo+gb2BRZp5QsHxnNA7rOzeYb49YENdgMRSoI7YTXqf5uEB7I7cZTQijnyKHE4O6IyQlLVT5GoIBfNp7Kr6UuAK+hm//2scUXBXHOlapJMteD/pXJ1ma31VOnBaqX14f5fXjrnfxdfgVuLOcBXUfc6hmHPCjTghQL3MudgzXuztIAmB4RJAABg1N0NlnE1qGRh+xLwzsziN3MPUDO5ZwGYQv/WpLSMqar7aegl31D4YLkmQAml1Tx0WTlrM="
+
+
+before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
+    # Remove homebrew.
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
+
+install:
+    # Install Miniconda.
+    - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      bash $MINICONDA_FILE -b
+
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
+      source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
+      conda config --add channels conda-forge
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
+
+script:
+  - conda build ./recipe
+
+  - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/vtk-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/vtk-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/vtk-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/vtk-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/vtk-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/vtk-feedstock/branch/master)
 
 Current release info
@@ -67,6 +67,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -33,5 +33,5 @@ cmake .. -G "Ninja" ^
     -DVTK_USE_SYSTEM_EXPAT:BOOL=ON
 if errorlevel 1 exit 1
 
-ninja install
+ninja install -j %CPU_COUNT%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,4 +48,4 @@ cmake .. -G "Ninja" \
     ${SCREEN_ARGS[@]}
 
 # compile & install!
-ninja install
+ninja install -j ${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,4 +48,4 @@ cmake .. -G "Ninja" \
     ${SCREEN_ARGS[@]}
 
 # compile & install!
-ninja install -j ${CPU_COUNT}
+ninja install -j 8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 1
-  skip: True  # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/vtk-feedstock/issues/10
Closes https://github.com/conda-forge/vtk-feedstock/pull/34

Attempts to get macOS packages built by enabling Travis CI.