### PR TITLE
Refresh manual pins

### DIFF
--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython2.7.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython2.7.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'
-zlib:
-- '1.2'

--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.5.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.5.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'
-zlib:
-- '1.2'

--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.6.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.6.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'
-zlib:
-- '1.2'

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython2.7.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython2.7.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'True'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'
-zlib:
-- '1.2'

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython3.5.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython3.5.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'True'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'
-zlib:
-- '1.2'

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython3.6.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython3.6.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'True'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'
-zlib:
-- '1.2'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -2,29 +2,13 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'
-zlib:
-- '1.2'

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -2,29 +2,13 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'
-zlib:
-- '1.2'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -2,29 +2,13 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'
-zlib:
-- '1.2'

--- a/.ci_support/win_python3.5.yaml
+++ b/.ci_support/win_python3.5.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'
-zlib:
-- '1.2'

--- a/.ci_support/win_python3.6.yaml
+++ b/.ci_support/win_python3.6.yaml
@@ -1,24 +1,8 @@
 VTK_WITH_OSMESA:
 - 'False'
-expat:
-- '2.2'
-freetype:
-- 2.8.1
-hdf5:
-- 1.10.1
-jpeg:
-- '9'
-libpng:
-- 1.6.32
-libtiff:
-- 4.0.8
-libxml2:
-- '2.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'
-zlib:
-- '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,7 @@ test:
 about:
   home: http://www.vtk.org/
   license: BSD 3-Clause
+  license_file: Copyright.txt
   summary: >
     The Visualization Toolkit (VTK) is an open-source, freely available software
     system for 3D computer graphics, modeling, image processing, volume

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "8.1.0" %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 
 {% set build_number = build_number + 200 %}   # [not VTK_WITH_OSMESA]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,30 +28,30 @@ requirements:
     - ninja
     - python
     # VTK Third Party dependencies
-    - zlib 1.2.*
-    - freetype 2.8.*
-    - hdf5 1.8.18|1.8.18.*  # [unix]
+    - zlib 1.2.11
+    - freetype 2.8.1
+    - hdf5 1.10.1  # [unix]
     - libxml2 2.9.*
-    - libpng >=1.6.23,<1.7
+    - libpng >=1.6.32,<1.6.35
     - jpeg 9*
-    - libtiff 4.0.*
+    - libtiff >=4.0.8,<4.0.10
     - jsoncpp  # [unix]
-    - expat
+    - expat 2.2.*
     - tbb
     - mesalib   # [VTK_WITH_OSMESA]
   run:
     - python
     - future  # used in the generated python wrappers
     # VTK Third Party dependencies
-    - zlib 1.2.*
-    - freetype 2.8.*
-    - hdf5 1.8.18|1.8.18.*  # [unix]
+    - zlib 1.2.11
+    - freetype 2.8.1
+    - hdf5 1.10.1  # [unix]
     - libxml2 2.9.*
-    - libpng >=1.6.23,<1.7
+    - libpng >=1.6.32,<1.6.35
     - jpeg 9*
-    - libtiff 4.0.*
+    - libtiff >=4.0.8,<4.0.10
     - jsoncpp  # [unix]
-    - expat
+    - expat 2.2.*
     - tbb
     - mesalib   # [VTK_WITH_OSMESA]
 


### PR DESCRIPTION
Based off of the [last state of the old pinning script]( https://github.com/conda-forge/conda-forge.github.io/blob/4c8b3b28ad45e6d46e268acf73de8c0da30de1bc/scripts/pin_the_slow_way.py ). This is a workaround until PR ( https://github.com/conda-forge/vtk-feedstock/pull/56 ) properly updates this feedstock to use the new pinnings. Also packages the license file.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
