### PR TITLE
Use xorg-libxt from conda-forge

### DIFF
--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython2.7.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython2.7.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.5.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.5.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.6.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESAFalsepython3.6.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython2.7.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython2.7.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython3.5.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython3.5.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/linux_VTK_WITH_OSMESATruepython3.6.yaml
+++ b/.ci_support/linux_VTK_WITH_OSMESATruepython3.6.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,9 +37,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -13,7 +13,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -43,9 +43,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -13,7 +13,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -43,9 +43,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -13,7 +13,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -43,9 +43,11 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/win_cxx_compilervs2015python3.5.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.5.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,15 +37,17 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
 zip_keys:
-- - cxx_compiler
-  - python
+- - python
+  - cxx_compiler
 zlib:
 - '1.2'

--- a/.ci_support/win_cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6.yaml
@@ -11,7 +11,7 @@ jpeg:
 jsoncpp:
 - 1.8.1
 libnetcdf:
-- '4.5'
+- '4.6'
 libpng:
 - 1.6.34
 libtiff:
@@ -37,15 +37,17 @@ pin_run_as_build:
     max_pin: x
   libxml2:
     max_pin: x.x
+  lz4-c:
+    max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.6'
 zip_keys:
-- - cxx_compiler
-  - python
+- - python
+  - cxx_compiler
 zlib:
 - '1.2'

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -32,7 +32,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libXt-devel mesa-libGLU-devel
+/usr/bin/sudo -n yum install -y mesa-libGLU-devel
 
 
 conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "8.1.1" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - lz4-c
     - libogg      # [unix]
     - libtheora   # [unix]
+    - xorg-libxt  # [linux]
   run:
     - python
     - future  # used in the generated python wrappers
@@ -62,6 +63,7 @@ requirements:
     - lz4-c
     - libogg      # [unix]
     - libtheora   # [unix]
+    - xorg-libxt  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,8 @@ requirements:
     - mesalib   # [VTK_WITH_OSMESA]
     - libnetcdf
     - lz4-c
-    - libogg     # [unix]
-    - libtheora  # [unix]
+    - libogg      # [unix]
+    - libtheora   # [unix]
   run:
     - python
     - future  # used in the generated python wrappers
@@ -60,8 +60,8 @@ requirements:
     - mesalib   # [VTK_WITH_OSMESA]
     - libnetcdf
     - lz4-c
-    - libogg     # [unix]
-    - libtheora  # [unix]
+    - libogg      # [unix]
+    - libtheora   # [unix]
 
 test:
   imports:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,2 +1,1 @@
-libXt-devel
 mesa-libGLU-devel


### PR DESCRIPTION
As we provide a package in `conda-forge` for `libXt`, switch to it instead of getting from `yum`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
