### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - Korijn
     - ivoflipse
     - Maxyme
     - ccordoba12


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.