### PR TITLE
Add Paraview conflict

### DIFF
--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -5,7 +5,7 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
-set -xeuo pipefail
+set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
@@ -28,12 +28,25 @@ fi
 ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
 
 if [ -z "$CONFIG" ]; then
-    echo "Need to set CONFIG env variable"
+    set +x
+    FILES=`ls .ci_support/linux_*`
+    CONFIGS=""
+    for file in $FILES; do
+        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
     exit 1
 fi
 
-pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
+if [ -z "${DOCKER_IMAGE}" ]; then
+    SHYAML_INSTALLED="$(shyaml --version || echo NO)"
+    if [ "${SHYAML_INSTALLED}" == "NO" ]; then
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+    else
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+    fi
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"

--- a/.circleci/run_osx_build.sh
+++ b/.circleci/run_osx_build.sh
@@ -2,19 +2,24 @@
 
 set -x
 
-echo "Removing homebrew from Circle CI to avoid conflicts."
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"
+
+echo "Removing homebrew from CI to avoid conflicts." && echo -en 'travis_fold:start:remove_homebrew\\r'
 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
 chmod +x ~/uninstall_homebrew
 ~/uninstall_homebrew -fq
 rm ~/uninstall_homebrew
+echo -en 'travis_fold:end:remove_homebrew\\r'
 
-echo "Installing a fresh version of Miniconda."
+echo "Installing a fresh version of Miniconda." && echo -en 'travis_fold:start:install_miniconda\\r'
 MINICONDA_URL="https://repo.continuum.io/miniconda"
 MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
 curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
+echo -en 'travis_fold:end:install_miniconda\\r'
 
-echo "Configuring conda."
+echo "Configuring conda." && echo -en 'travis_fold:start:configure_conda\\r'
 source ~/miniconda3/bin/activate root
 
 conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
@@ -25,6 +30,7 @@ setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
 source run_conda_forge_build_setup
 
 
+echo -en 'travis_fold:end:configure_conda\\r'
 
 set -e
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Current build status
       </details>
     </td>
   </tr>
+![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
 </table>
 
 Current release info

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "8.2.0" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,10 @@ requirements:
     - lz4-c
     - xorg-libxt  # [linux]
 
+  run_constrained:
+    # Paraview bundles its own VTK that has conflicting Python vtkmodules
+    - paraview ==9999999999
+
 test:
   imports:
     - vtk


### PR DESCRIPTION
Paraview installs its internally bundled VTK python modules to the same path as this feedstock, creating a conflict.

I used the method described [here](http://conda-forge.org/docs/maintainer/adding_pkgs.html?highlight=run_constrained#defining-blockers) to define a conflict.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This came up in the course of investigating #83, which I think is an issue with the Paraview feedstock rather than this one.
