### PR TITLE
Add missing run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ source:
 
 build:
   number: {{ build }}
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
   # typically, osmesa is selected by installing or not installing
   # mesalib, but it could also be selected via the build string:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   number: {{ build }}
   run_exports:
-    - {{ pin_subpackage(name, max_pin='x.x.x') }}
+    - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 
   # typically, osmesa is selected by installing or not installing
   # mesalib, but it could also be selected via the build string:


### PR DESCRIPTION
ABI stability does not seem to be great (https://abi-laboratory.pro/?view=timeline&l=vtk) so suggesting x.x.x

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
