### PR TITLE
BUG: Fix bug with hash in filename

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.3.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 
@@ -10,8 +10,6 @@
 # `vtk * osmesa*` for osmesa
 # `vtk * egl*` for egl
 # `vtk * qt-main*` for qt-main
-{% set build_string = '{}_py{}h{}_{}'.format(build_variant, CONDA_PY, PKG_HASH, build) %}
-
 # The 'build: string: ...' needs to be set in each output and the top-level
 # otherwise it won't be correct in the final build.
 
@@ -31,12 +29,12 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ build_string }}
+  string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
 
 outputs:
   - name: vtk-base
     build:
-      string: {{ build_string }}
+      string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
       script: ${RECIPE_DIR}/build-base.sh  # [not win]
       script: "%RECIPE_DIR%\\bld-base.bat"  # [win]
       ignore_run_exports_from:
@@ -202,7 +200,7 @@ outputs:
 
   - name: vtk-io-ffmpeg
     build:
-      string: {{ build_string }}
+      string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
       script: ${RECIPE_DIR}/build-io-ffmpeg.sh  # [not win]
       skip: true  # [win]
       run_exports:
@@ -225,7 +223,7 @@ outputs:
 
   - name: vtk
     build:
-      string: {{ build_string }}
+      string: "{{ build_variant }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
       run_exports:
         - {{ pin_subpackage('vtk-base', max_pin='x.x.x') }}
     requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

In adapting the `build_variant` mechanics for another repo (thanks for the clear comments and usage!) I noticed that the hashes for the VTK packages are just `1234567` (because I was getting these for mine, too):

![Screenshot from 2024-07-08 16-57-35](https://github.com/conda-forge/vtk-feedstock/assets/2365790/5d519a4c-2cb4-4ce5-9bbf-4206cc0fe332)

Making these template substitutions seems to fix the problem for me in my packages. Opening this PR to see if they fix them here, too. In theory it should be visible in the last few lines of each CI run that it has been fixed, e.g. for my repo (this is in the middle of the run during installation for the test step):

![image](https://github.com/conda-forge/vtk-feedstock/assets/2365790/ef3ea582-5606-4d98-a3f8-40bdf429b3a7)

If this does fix things, it's possible that it's an upstream bug, or just some misuse of templating, not sure :shrug: 

*EDIT: This also more closely matches the example in the docs: https://conda-forge.org/docs/maintainer/knowledge_base/*