### PR TITLE
MAINT: Build against latest qt6-main

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.3.1" %}
-{% set build = 10 %}
+{% set build = 11 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,7 @@ outputs:
       host:
         - python
         - zlib
+        - liblzma-devel
         - freetype
         - hdf5
         - hdf5 * nompi_*


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I know #354 is in progress, but in the meantime I think just ticking the build number and merging should fix incompatibility with the latest `qt6-main`, i.e. allow this to succeed:
```
$ conda create -n vtktest "vtk=9.3.1=*qt*" "qt6-main=6.8.1"
Channels:
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package vtk-base-9.3.1-qt_py312h1234567_200 requires qt6-main >=6.7.2,<6.8.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ qt6-main 6.8.1**  is installable with the potential options
│  ├─ qt6-main 6.8.1, which can be installed;
│  └─ qt6-main 6.8.1 would require
│     └─ libxcb >=1.16,<1.17.0a0 , which can be installed;
└─ vtk 9.3.1 *qt* is not installable because there are no viable options
   ├─ vtk 9.3.1 would require
   │  └─ vtk-base [9.3.1 qt_py310h1234567_200|9.3.1 qt_py310h2c847e9_204|...|9.3.1 qt_py39hff486e7_206], which requires
   │     └─ qt6-main >=6.7.2,<6.8.0a0 , which conflicts with any installable versions previously reported;
   └─ vtk 9.3.1 would require
      └─ vtk-base [9.3.1 qt_py310h9617cfe_209|9.3.1 qt_py311h7158b74_209|9.3.1 qt_py312hc73667e_209|9.3.1 qt_py313h576883f_209|9.3.1 qt_py39he1f0fb8_209], which requires
         ├─ libxcb >=1.17.0,<2.0a0 , which conflicts with any installable versions previously reported;
         └─ qt6-main >=6.7.3,<6.8.0a0 , which conflicts with any installable versions previously reported.
```
Even if 9.4 lands soon it would still be nice to have a 9.3.1 variant that works with newer Qt (e.g., for PyVista which now pins to `<9.4` until they improve compat).

(FYI my motivation is that VTK is currently the only dependency holding me back from using PySide 6.8 in a standalone installer I'm creating.)