### PR TITLE
Add python dependency in vtk-io-ffmpeg and relax exact dependencies on vtk subpackages in vtk metapackage 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -203,8 +203,10 @@ outputs:
     requirements:
       build: []
       host:
-        # We use ffmpeg here in the host section so that conda build
-        # uses the global pinnings and ensures ffmpeg compatibility.
+        # We use python and ffmpeg here in the host section so that conda build
+        # uses the global pinnings and ensures compatibility, as both ffmpeg and python
+        # are dependency of the package
+        - python
         - ffmpeg
       run:
         - {{ pin_subpackage("vtk-base", exact=True) }}
@@ -218,20 +220,16 @@ outputs:
 
   - name: vtk
     build:
-      ignore_run_exports_from:
-        - ffmpeg
       run_exports:
         - {{ pin_subpackage('vtk-base', max_pin='x.x.x') }}
     requirements:
       build: []
-      host:
-        # We include ffmpeg in the host dependency so the PKG_HASH is different between
-        # ffmpeg==6 and ffmpeg==7 builds, avoiding the issue described in
-        # https://github.com/conda-forge/vtk-feedstock/issues/347
-        - ffmpeg
+      host: []
       run:
-        - {{ pin_subpackage("vtk-base", exact=True) }}
-        - {{ pin_subpackage("vtk-io-ffmpeg", exact=True) }}  # [not win]
+        # The pin_subpackage is not exact to avoid issues like https://github.com/conda-forge/vtk-feedstock/issues/347
+        # and https://github.com/conda-forge/vtk-feedstock/issues/372
+        - {{ pin_subpackage("vtk-base", upper_bound='x.x.x') }}
+        - {{ pin_subpackage("vtk-io-ffmpeg", upper_bound='x.x.x') }}  # [not win]
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ outputs:
         - libuuid  # [linux]
         # still missing: Xaccessrules Xxf86misc, xcb_errors, xcb_xrm
         - xorg-xproto  # [linux]
+        - xorg-libxcursor  # [linux]
         - xorg-libxft  # [linux]
         - xorg-libxt  # [linux]
         - xorg-libxv  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,8 +228,8 @@ outputs:
       run:
         # The pin_subpackage is not exact to avoid issues like https://github.com/conda-forge/vtk-feedstock/issues/347
         # and https://github.com/conda-forge/vtk-feedstock/issues/372
-        - {{ pin_subpackage("vtk-base", upper_bound='x.x.x') }}
-        - {{ pin_subpackage("vtk-io-ffmpeg", upper_bound='x.x.x') }}  # [not win]
+        - {{ pin_subpackage("vtk-base", max_pin='x.x.x') }}
+        - {{ pin_subpackage("vtk-io-ffmpeg", max_pin='x.x.x') }}  # [not win]
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.4.1" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 


### PR DESCRIPTION
Fix https://github.com/conda-forge/vtk-feedstock/issues/372 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
