### PR TITLE
Add check for find_package(VTK) on vtk output

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2019
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2019
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2019
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2019
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2019
 c_stdlib:
 - vs
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.4.1" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 
@@ -231,15 +231,21 @@ outputs:
         # and https://github.com/conda-forge/vtk-feedstock/issues/372
         - {{ pin_subpackage("vtk-base", max_pin='x.x.x') }}
         - {{ pin_subpackage("vtk-io-ffmpeg", max_pin='x.x.x') }}  # [not win]
+        # This is done to ensure that find_package(VTK) works fine
+        - tbb-devel
     test:
       requires:
         - pip
         - setuptools
+        - cmake-package-check
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
       imports:
         - vtk
         - vtk.vtkIOFFMPEG  # [not win]
       commands:
         - python test_vtk.py
+        - cmake-package-check VTK
 
 about:
   home: http://www.vtk.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -119,6 +119,10 @@ outputs:
         # we use the internal one in build-base.sh
         - gl2ps  # [not osx]
         - qt6-main  # [not ppc64le]
+        # Additional qt6-main pin as a workaround for https://github.com/conda-forge/vtk-feedstock/pull/375#issuecomment-2760685256
+        # remove once we mirate to qt6-main 6.10
+        - qt6-main 6.8.0.*  # [not ppc64le]
+        
       run:
         - python
         - utfcpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,7 +121,7 @@ outputs:
         - qt6-main  # [not ppc64le]
         # Additional qt6-main pin as a workaround for https://github.com/conda-forge/vtk-feedstock/pull/375#issuecomment-2760685256
         # remove once we mirate to qt6-main 6.10
-        - qt6-main 6.8.0.*  # [not ppc64le]
+        - qt6-main 6.8.2.*  # [not ppc64le]
         
       run:
         - python


### PR DESCRIPTION
This PR aims to find `find_package(VTK)` once a user installs the `vtk` package, and investigate the failures in https://github.com/conda-forge/vtk-feedstock/pull/373#issuecomment-2758462580.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
