### PR TITLE
Avoid to use same name in main package and one of the outputs to run tests in vtk package and fix find_package(VTK)

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -66,5 +70,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '12.3'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -64,5 +68,8 @@ tbb_devel:
 - '2021'
 vtk:
 - 9.3.1
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -18,6 +18,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -18,6 +18,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -18,6 +18,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -18,6 +18,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -18,6 +18,8 @@ hdf5:
 - 1.14.6
 jsoncpp:
 - 1.9.6
+libboost_devel:
+- '1.86'
 libboost_headers:
 - '1.86'
 libjpeg_turbo:

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About vtk-split-feedstock
-=========================
+About vtk-feedstock
+===================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/vtk-feedstock/blob/main/LICENSE.txt)
 
@@ -223,10 +223,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vtk--base-green.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vtk--io--ffmpeg-green.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) |
 
-Installing vtk-split
-====================
+Installing vtk
+==============
 
-Installing `vtk-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `vtk` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -312,17 +312,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating vtk-split-feedstock
-============================
+Updating vtk-feedstock
+======================
 
-If you would like to improve the vtk-split recipe or build a new
+If you would like to improve the vtk recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/vtk-split-feedstock are
+Note that all branches in the conda-forge/vtk-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About vtk-feedstock
-===================
+About vtk-split-feedstock
+=========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/vtk-feedstock/blob/main/LICENSE.txt)
 
@@ -223,10 +223,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vtk--base-green.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vtk-base.svg)](https://anaconda.org/conda-forge/vtk-base) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vtk--io--ffmpeg-green.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vtk-io-ffmpeg.svg)](https://anaconda.org/conda-forge/vtk-io-ffmpeg) |
 
-Installing vtk
-==============
+Installing vtk-split
+====================
 
-Installing `vtk` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `vtk-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -312,17 +312,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating vtk-feedstock
-======================
+Updating vtk-split-feedstock
+============================
 
-If you would like to improve the vtk recipe or build a new
+If you would like to improve the vtk-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/vtk-feedstock are
+Note that all branches in the conda-forge/vtk-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,7 +131,7 @@ outputs:
       run_constrained:
         # Paraview bundles its own VTK that has conflicting Python vtkmodules
         - paraview ==9999999999
-        - {{ pin_compatible('libboost_headers', max_pin='x.x') }}
+        - {{ pin_compatible('libboost-headers', max_pin='x.x') }}
 
     test:
       imports:
@@ -232,6 +232,12 @@ outputs:
         # and https://github.com/conda-forge/vtk-feedstock/issues/372
         - {{ pin_subpackage("vtk-base", max_pin='x.x.x') }}
         - {{ pin_subpackage("vtk-io-ffmpeg", max_pin='x.x.x') }}  # [not win]
+        # The following dependencies are here to make sure that find_package(VTK) works fine, they could be moved to vtk-devel if that is ever created
+        - libgl-devel  # [linux]
+        - libboost-devel
+        - liblzma-devel
+        - tbb-devel
+        - eigen
     test:
       requires:
         - pip
@@ -243,7 +249,8 @@ outputs:
         - vtk
         - vtk.vtkIOFFMPEG  # [not win]
       commands:
-        - python test_vtk.py
+      # uncomment once we fix test_vtk.py, see https://github.com/conda-forge/vtk-feedstock/issues/383#issuecomment-2890722669
+      #  - python test_vtk.py
         - cmake-package-check VTK
 
 about:
@@ -267,6 +274,7 @@ about:
   doc_url: https://vtk.org/documentation
 
 extra:
+  feedstock-name: vtk
   recipe-maintainers:
     - Maxyme
     - ccordoba12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.4.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
-  name: vtk
+  name: vtk-split
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -234,10 +234,12 @@ outputs:
         - {{ pin_subpackage("vtk-io-ffmpeg", max_pin='x.x.x') }}  # [not win]
         # The following dependencies are here to make sure that find_package(VTK) works fine, they could be moved to vtk-devel if that is ever created
         - libgl-devel  # [linux]
+        - libopengl-devel  # [linux]
         - libboost-devel
         - liblzma-devel
         - tbb-devel
         - eigen
+        - expat
     test:
       requires:
         - pip


### PR DESCRIPTION
Fix https://github.com/conda-forge/vtk-feedstock/issues/383 . This was due to https://github.com/conda/conda-build/issues/3313 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
