### PR TITLE
Limit hdf5 to <2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -59,7 +59,7 @@ outputs:
         - zlib
         - liblzma-devel
         - freetype
-        - hdf5
+        - hdf5 <2
         - hdf5 * nompi_*
         - libxml2-devel
         - libpng


### PR DESCRIPTION
VTK is incompatible with hdf5 2. Pin the host dependency to `<2`.